### PR TITLE
tr53 - reconfigure notifications to take message as input

### DIFF
--- a/backend/pkg/handler/handlers.go
+++ b/backend/pkg/handler/handlers.go
@@ -117,11 +117,24 @@ func (h *FriendsHandler) GetRandomFriend(c *gin.Context) {
 	if url != "" {
 		switch notification_svc {
 		case "DISCORD":
-			models.SendDiscordNotification(randomFriend, url)
+			var content = "You should get in touch with " + randomFriend.Name + ". You haven't spoken to them since " +
+				randomFriend.LastContacted + ". "
+
+			if randomFriend.Notes != "" {
+				content = content + "Here's what you've got written down for them: " + randomFriend.Notes
+			}
+
+			models.SendDiscordNotification(randomFriend, url, content)
 		case "TELEGRAM":
 			// Logic for Telegram notifications
 		case "NTFY":
-			models.SendNtfyNotification(randomFriend, url)
+			var content = "You should get in touch with " + randomFriend.Name + ". You haven't spoken to them since " +
+				randomFriend.LastContacted + ". "
+
+			if randomFriend.Notes != "" {
+				content = content + "Here's what you've got written down for them: " + randomFriend.Notes
+			}
+			models.SendNtfyNotification(randomFriend, url, content)
 		default:
 			// Default logic or error handling
 		}

--- a/backend/pkg/models/models.go
+++ b/backend/pkg/models/models.go
@@ -207,15 +207,8 @@ func PickRandomFriend(friends FriendsList) (Friend, error) {
 
 // Notifications
 
-func SendDiscordNotification(friend Friend, url string) {
+func SendDiscordNotification(friend Friend, url string, content string) {
 	var username = "HowAreThey"
-
-	var content = "You should get in touch with " + friend.Name + ". You haven't spoken to them since " +
-		friend.LastContacted + ". "
-
-	if friend.Notes != "" {
-		content = content + "Here's what you've got written down for them: " + friend.Notes
-	}
 
 	// Create the payload
 	payload := DiscordWebhookPayload{
@@ -237,16 +230,9 @@ func SendDiscordNotification(friend Friend, url string) {
 	defer resp.Body.Close()
 }
 
-func SendNtfyNotification(friend Friend, url string) {
-	var message = "You should get in touch with " + friend.Name + ". You haven't spoken to them since " +
-		friend.LastContacted + ". "
-
-	if friend.Notes != "" {
-		message = message + "Here's what you've got written down for them: " + friend.Notes
-	}
-
+func SendNtfyNotification(friend Friend, url string, content string) {
 	// Send the POST request
-	resp, err := http.Post(url, "text/plain", bytes.NewBufferString(message))
+	resp, err := http.Post(url, "text/plain", bytes.NewBufferString(content))
 	if err != nil {
 		logger.LogMessage(logger.LogLevelWarn, "Failed to send the request: %s", err)
 	}


### PR DESCRIPTION
In preparation to schedule the birthday check I need to allow passing in the message content to the send notification functions